### PR TITLE
add package urls to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,8 @@ pyglet
 # https://www.lfd.uci.edu/~gohlke/pythonlibs
 #
 # meshpy
+https://github.com/JosephSamela/python-package-hosted/blob/master/MeshPy-2018.2.1-cp37-cp37m-win_amd64.whl?raw=true
 # shapely
+https://github.com/JosephSamela/python-package-hosted/blob/master/Shapely-1.7.0-cp37-cp37m-win_amd64.whl?raw=true
 # rtree
+https://github.com/JosephSamela/python-package-hosted/blob/master/Rtree-0.9.4-cp37-cp37m-win_amd64.whl?raw=true


### PR DESCRIPTION
This commit adds url for the "weird" packages `meshpy`, `shapely` and `rtree`. 

I would prefer to reference them directly from https://www.lfd.uci.edu/~gohlke/pythonlibs/ however those downloads are behind a javascript redirect. To get around this, I rehosted them at https://github.com/JosephSamela/python-package-hosted.

The downside of this approach is these are python 3.7 specific.