### PR TITLE
Build pychop3d as python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,8 @@ pyglet
 # https://www.lfd.uci.edu/~gohlke/pythonlibs
 #
 # meshpy
+https://github.com/JosephSamela/python-package-hosted/blob/master/MeshPy-2018.2.1-cp37-cp37m-win_amd64.whl?raw=true
 # shapely
+https://github.com/JosephSamela/python-package-hosted/blob/master/Shapely-1.7.0-cp37-cp37m-win_amd64.whl?raw=true
 # rtree
+https://github.com/JosephSamela/python-package-hosted/blob/master/Rtree-0.9.4-cp37-cp37m-win_amd64.whl?raw=true

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='pychop3d',
+    version='alpha-1',
+    description='Python implementation of "Chopper: Partitioning Models into 3D-Printable Parts"',
+    url='https://github.com/gregstarr/pychop3d',
+    author='gregstarr',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6',
+    ],
+    packages=['pychop3d'],
+    package_dir={'pychop3d': 'pychop3d'},
+    python_requires='!=3.6.',
+    install_requires=[
+        'matplotlib',
+        'numpy',
+        'scipy',
+        'pytest',
+        'networkx',
+        'pyyaml',
+        'requests',
+        'trimesh',
+        'pyglet'
+    ],
+    project_urls={
+        'Bug Reports': 'https://github.com/gregstarr/pychop3d/issues',
+        'Source': 'https://github.com/gregstarr/pychop3d',
+    }
+)


### PR DESCRIPTION
This PR adds a `setup.py` for building pychop3d as a python package. Here's an alpha version of the package I built for testing. Please try it out and give feedback! 

https://github.com/JosephSamela/pychop3d/releases/tag/alpha-1

After installing, you can import the package like normal. For example...

```python
from pychop3d import utils
```

NOTICE! I did not run tests against `alpha-1`. I'll try those out and report back when I get a chance.